### PR TITLE
[change]:環境構築でコマンドが少なくなるようDocker仕様変更

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 FROM ruby:3.2.2
 
 # PostgreSQLクライアントをインストール
-RUN apt-get update -qq && apt-get install -y postgresql-client
+RUN apt-get update -qq && apt-get install -y postgresql-client vim
 RUN mkdir /app
 WORKDIR /app
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
 set -e
 
+# Railsサーバーが起動する前にDBが存在するか確認し、なければ作成
+rails db:create || true
+
 # Remove a potentially pre-existing server.pid for Rails.
 rm -f /myapp/tmp/pids/server.pid
 


### PR DESCRIPTION
レビューしてもらう際、環境構築で必要なコマンドが多かった為、Dockerを見直しました。

【変更点】

- 初めて環境構築した際`rails db:create`が必要でしたが、ビルド時にcreateされるようentrypointを変更しました。
- credentials.ymlを編集する際editorのインストールが必要だった為、ビルド時にvimをインストールするよう設定しました。

